### PR TITLE
Fix/py314 lru cache patch

### DIFF
--- a/psll/__init__.py
+++ b/psll/__init__.py
@@ -2,7 +2,7 @@
 Macro-driven metalanguage which compiles to Pyramid Scheme.
 """
 
-__version__ = "0.1.8"
+__version__ = "0.1.9"
 
 
 class PsllSyntaxError(SyntaxError):

--- a/psll/build.py
+++ b/psll/build.py
@@ -1,8 +1,29 @@
 import operator
+import sys
 from functools import lru_cache, reduce, singledispatch
 from typing import Union, overload
 
 from .ascii_trees import AbstractTree, Pyramid
+
+if sys.version_info >= (3, 14):
+    # Fix for lru_cache in Python 3.14+
+    from functools import wraps
+    from typing import Any, Callable
+
+    _old_lru_cache = lru_cache
+
+    def wrapped_lru_cache[T: Callable](*lru_args, **lru_kwargs) -> Callable[[T], T]:
+        def decorator(func: T) -> T:
+            @wraps(func)
+            def wrapper(*args: Any, **kwargs: Any) -> Any:
+                return _old_lru_cache(*lru_args, **lru_kwargs)(func)(*args, **kwargs)
+
+            return wrapper  # type: ignore
+
+        return decorator
+
+    lru_cache = wrapped_lru_cache
+
 
 # ===================================================================================
 #

--- a/psll/build.py
+++ b/psll/build.py
@@ -7,6 +7,7 @@ from .ascii_trees import AbstractTree, Pyramid
 
 if sys.version_info >= (3, 14):
     # Fix for lru_cache in Python 3.14+
+    # See: https://github.com/python/cpython/issues/132064
     from functools import wraps
     from typing import Any, Callable
 

--- a/psll/build.py
+++ b/psll/build.py
@@ -9,21 +9,23 @@ if sys.version_info >= (3, 14):
     # Fix for lru_cache in Python 3.14+
     # See: https://github.com/python/cpython/issues/132064
     from functools import wraps
-    from typing import Any, Callable
+    from typing import Any, Callable, TypeVar
 
     _old_lru_cache = lru_cache
 
-    def wrapped_lru_cache[T: Callable](*lru_args, **lru_kwargs) -> Callable[[T], T]:
-        def decorator(func: T) -> T:
+    _T = TypeVar("_T", bound=Callable)
+
+    def wrapped_lru_cache(*lar: Any, **lkw: Any) -> Callable[[_T], _T]:
+        def decorator(func: _T) -> _T:
             @wraps(func)
-            def wrapper(*args: Any, **kwargs: Any) -> Any:
-                return _old_lru_cache(*lru_args, **lru_kwargs)(func)(*args, **kwargs)
+            def wrapper(*ar: Any, **kw: Any) -> Any:
+                return _old_lru_cache(*lar, **lkw)(func)(*ar, **kw)
 
             return wrapper  # type: ignore
 
         return decorator
 
-    lru_cache = wrapped_lru_cache
+    lru_cache = wrapped_lru_cache  # type: ignore
 
 
 # ===================================================================================

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 min_version = 4.0
 env_list =
     ; py314t
-    ; py314  # FIXME: BROKEN!!
+    py314
     ; py313t
     py313
     py312


### PR DESCRIPTION
Future proof against [this](https://github.com/python/cpython/issues/132064) issue in py314, hence enable tox for py314.